### PR TITLE
juice: fix duplicate on system.prop

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -20,13 +20,11 @@ vendor.bluetooth.soc=cherokee
 # Dex
 pm.dexopt.ab-ota=extract
 pm.dexopt.install=speed-profile
-pm.dexopt.boot=extract
 pm.dexopt.first-boot=quicken
 dalvik.vm.dex2oat-cpu-set=0,1,5,6
 dalvik.vm.dex2oat-threads=4
 dalvik.vm.dex2oat-filter=quicken
 dalvik.vm.image-dex2oat-cpu-set=0,1,5,6
-dalvik.vm.image-dex2oat-filter=quicken
 dalvik.vm.image-dex2oat-threads=4
 ro.vendor.qti.am.reschedule_service=true
 ro.sys.fw.dex2oat_thread_count=8


### PR DESCRIPTION
FAILED: /tmp/rom/out/target/product/juice/system/build.prop
/bin/bash -c "(rm -f /tmp/rom/out/target/product/juice/system/build.prop && touch /tmp/rom/out/target/product/juice/system/build.prop ) && (BUILD_UTC_DATE=0     bash -c ' BUILD_UTC_DATE=0; echo \"####################################\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"# from generate-common-build-props\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"# These properties identify this partition image.\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"####################################\" >> /tmp/rom/out/target/product/juice/system/build.prop;  echo \"ro.product.system.brand=Xiaomi\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"ro.product.system.device=juice\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"ro.product.system.manufacturer=Xiaomi\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"ro.product.system.model=sm6115\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"ro.product.system.name=cherish_juice\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.system.product.cpu.abilist=arm64-v8a,armeabi-v7a,armeabi \" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"ro.system.product.cpu.abilist32=armeabi-v7a,armeabi\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"ro.system.product.cpu.abilist64=arm64-v8a\" >> /tmp/rom/out/target/product/juice/system/build.prop;  echo \"ro.system.build.date=\`date -d @\$(cat /tmp/rom/out/build_date.txt)\`\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"ro.system.build.date.utc=\`date -d @\$(cat /tmp/rom/out/build_date.txt) +%s\`\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"ro.system.build.fingerprint=\$(cat /tmp/rom/out/target/product/juice/build_fingerprint.txt)\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"ro.system.build.id=SQ1D.220205.004\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"ro.system.build.tags=test-keys\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"ro.system.build.type=eng\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"ro.system.build.version.incremental=\$(cat /tmp/rom/out/soong/build_number.txt)\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"ro.system.build.version.release=12\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"ro.system.build.version.release_or_codename=12\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"ro.system.build.version.sdk=31\" >> /tmp/rom/out/target/product/juice/system/build.prop; ' ) && (if [ -f \"/tmp/rom/out/target/product/juice/obj/PACKAGING/system_build_prop_intermediates/buildinfo.prop\" ]; then echo \"\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"####################################\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"# from /tmp/rom/out/target/product/juice/obj/PACKAGING/system_build_prop_intermediates/buildinfo.prop\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"####################################\" >> /tmp/rom/out/target/product/juice/system/build.prop; cat /tmp/rom/out/target/product/juice/obj/PACKAGING/system_build_prop_intermediates/buildinfo.prop >> /tmp/rom/out/target/product/juice/system/build.prop; fi;  if [ -f \"device/xiaomi/juice/system.prop\" ]; then echo \"\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"####################################\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"# from device/xiaomi/juice/system.prop\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"####################################\" >> /tmp/rom/out/target/product/juice/system/build.prop; cat device/xiaomi/juice/system.prop >> /tmp/rom/out/target/product/juice/system/build.prop; fi ) && (echo \"\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"####################################\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"# from variable ADDITIONAL_SYSTEM_PROPERTIES\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"####################################\" >> /tmp/rom/out/target/product/juice/system/build.prop;  echo \"ro.product.first_api_level=29\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"pm.dexopt.boot=verify\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"pm.dexopt.first-boot=quicken\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"pm.dexopt.install=speed-profile\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"pm.dexopt.bg-dexopt=everything\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"persist.sys.wfd.nohdcp=1\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"persist.debug.wfd.enable=1\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"persist.sys.wfd.virtual=0\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.treble.enabled=true\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.actionable_compatible_property.enabled=true\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"persist.debug.dalvik.vm.core_platform_api_policy=just-warn\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.postinstall.fstab.prefix=/system\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.kernel.android.checkjni=1\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.secure=0\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.allow.mock.location=1\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.debuggable=1\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.lockprof.threshold=500\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.image-dex2oat-filter=extract\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"net.bt.name=Android\" >> /tmp/rom/out/target/product/juice/system/build.prop;    echo \"\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"####################################\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"# from variable PRODUCT_SYSTEM_PROPERTIES\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"####################################\" >> /tmp/rom/out/target/product/juice/system/build.prop;  echo \"debug.atrace.tags.enableflags=0\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"persist.traced.enable=1\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.image-dex2oat-Xms=64m\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.image-dex2oat-Xmx=64m\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.dex2oat-Xms=64m\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.dex2oat-Xmx=512m\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.usejit=true\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.usejitprofiles=true\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.dexopt.secondary=true\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.dexopt.thermal-cutoff=2\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.appimageformat=lz4\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.dalvik.vm.native.bridge=0\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"pm.dexopt.first-boot?=extract\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"pm.dexopt.boot-after-ota?=extract\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"pm.dexopt.post-boot?=extract\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"pm.dexopt.install?=speed-profile\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"pm.dexopt.install-fast?=skip\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"pm.dexopt.install-bulk?=speed-profile\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"pm.dexopt.install-bulk-secondary?=verify\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"pm.dexopt.install-bulk-downgraded?=verify\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"pm.dexopt.install-bulk-secondary-downgraded?=extract\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"pm.dexopt.bg-dexopt?=speed-profile\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"pm.dexopt.ab-ota?=speed-profile\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"pm.dexopt.inactive?=verify\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"pm.dexopt.cmdline?=verify\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"pm.dexopt.shared?=speed\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.dex2oat-updatable-bcp-packages-file=/system/etc/updatable-bcp-packages.txt\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.dex2oat-resolve-startup-strings=true\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.dex2oat-max-image-block-size=524288\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.minidebuginfo=true\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.dex2oat-minidebuginfo=true\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.iorapd.enable?=true\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.madvise.vdexfile.size=104857600\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.madvise.odexfile.size=104857600\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.madvise.artfile.size=4294967295\" >> /tmp/rom/out/target/product/juice/system/build.prop;    echo \"\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"####################################\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"# from variable PRODUCT_SYSTEM_DEFAULT_PROPERTIES\" >> /tmp/rom/out/target/product/juice/system/build.prop; echo \"####################################\" >> /tmp/rom/out/target/product/juice/system/build.prop;  echo \"net.tethering.noprovisioning=true\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.cherish.version=3.4.5\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.cherish.version.display=Cherish-OS-v3.4.5-20220326-0939-juice-UNOFFICIAL-GApps\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.cherish.build_date=20220326-0939\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.cherish.codename=Beta\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.cherish.version.prop=12\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.cherish.build_date_utc=\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.cherish.build_type=UNOFFICIAL\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.com.google.clientidbase=android-xiaomi\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"dalvik.vm.debug.alloc=0\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.url.legal=http://www.google.com/intl/%s/mobile/android/basic/phone-legal.html\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.url.legal.android_privacy=http://www.google.com/intl/%s/mobile/android/basic/privacy.html\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.error.receiver.system.apps=com.google.android.gms\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.com.android.dataroaming=false\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.atrace.core.services=com.google.android.gms,com.google.android.gms.ui,com.google.android.gms.persistent\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.com.android.dateformat=MM-dd-yyyy\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"persist.sys.disable_rescue=true\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.adb.secure=0\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.control_privapp_permissions=log\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.storage_manager.enabled=true\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"media.recorder.show_manufacturer_and_model=true\" >> /tmp/rom/out/target/product/juice/system/build.prop;   echo \"ro.face_unlock_service.enabled=true\" >> /tmp/rom/out/target/product/juice/system/build.prop ) && (/tmp/rom/out/host/linux-x86/bin/post_process_props  --sdk-version 31 /tmp/rom/out/target/product/juice/system/build.prop   ro.product.first_api_level ) && (echo \"# end of file\" >> /tmp/rom/out/target/product/juice/system/build.prop )"
error: found duplicate sysprop assignments:
dalvik.vm.image-dex2oat-filter=quicken
dalvik.vm.image-dex2oat-filter=extract
error: found duplicate sysprop assignments:
pm.dexopt.boot=extract
pm.dexopt.boot=verify